### PR TITLE
Bugfix: no longer reverses lists and seqs

### DIFF
--- a/src/gui_diff/internal.clj
+++ b/src/gui_diff/internal.clj
@@ -52,8 +52,11 @@
             (into (map-in-order-by-class x comps true)
                   (map-in-order-by-class x uncomps false)))
 
+          (vector? x)
+          (into [] (map nested-sort x))
+
           (sequential? x)
-          (into (empty x) (map nested-sort x))
+          (reverse (into '() (map nested-sort x)))
           
           :else
           x)))

--- a/test/gui_diff/test/internal_test.clj
+++ b/test/gui_diff/test/internal_test.clj
@@ -21,6 +21,17 @@
     nil nil
     #{} #{}
 
+    ;; plain sequences do not get sorted
+    [1 4 3] [1 4 3]
+    (map identity [1 4 3]) '(1 4 3)
+    '(1 4 3) '(1 4 3)
+    ;; but their contents do
+    [#{2 1 20000 3 4} {:c 1 :a 2 :b 3}]
+    [#{1 2 3 4 20000} {:a 2 :b 3 :c 1}]
+    
+    '({"conj" conj, "inc" inc, "dec" dec} #{"f" "m" "3"})
+    '({"conj" conj, "dec" dec, "inc" inc} #{"3" "f" "m"})
+
     ;;
     
     {:b 1 :a 2}


### PR DESCRIPTION
The Curse of Conj: it's easy to forget that `(into (empty x) (map f x)` will produce oppositely-ordered lists depending on whether x is a vector or a list/seq
