### PR TITLE
fix the gui-diff macro and its test

### DIFF
--- a/src/gui/diff.clj
+++ b/src/gui/diff.clj
@@ -175,15 +175,15 @@
         file-2 (doto (File/createTempFile
                       (str "b_gui_diff" (java.util.UUID/randomUUID)) ".txt")
                  .deleteOnExit)]
-    (spit file-1 expected)
-    (spit file-2 actual)
+    (spit file-1 (p-str expected))
+    (spit file-2 (p-str actual))
     (diff-files file-1 file-2)))
 
 (defmacro gui-diff
   "Display a visual diff of two data structures, a and b. On Mac uses FileMerge.
    On Linux, first tries to use Meld, then falls back to diff."
   [a b]
-  (gui-diff-strings (p-str a) (p-str b)))
+  `(gui-diff-strings '~a '~b))
 
 (defn- ct-output->gui-diff-report [ct-report-str]
   (-> ct-report-str

--- a/test/gui/test/diff_test.clj
+++ b/test/gui/test/diff_test.clj
@@ -131,8 +131,14 @@ expected: (= {:A 1} {:a 1, :b 2, :c 3, :d 4, :e 5})
          (#'gd/ct-report-str->failure-maps different-heights-FAIL))))
 
 (deftest no-evaluate-args
-  (is (= nil (gd/gui-diff (1 2 3) (4 5 6))))
-  (is (= nil (gd/gui-diff '(1 2 3) '(4 5 6)))))
+  (testing "gui diff does not evaluate its args"
+    (is (= (macroexpand '(gui.diff/gui-diff (1 2 3)
+                                            (4 5 6)))
+           '(gui.diff/gui-diff-strings (quote (1 2 3))
+                                       (quote (4 5 6)))))
+    (is (= '[(1 2 3) (4 5 6)]
+           (with-redefs [gui.diff/gui-diff-strings vector]
+             (gd/gui-diff (1 2 3) (4 5 6)))))))
 
 (def regression-string-2
   "


### PR DESCRIPTION
Fix obvious problem with macro version of gui-diff I added,
and improve the test:
1. verify the macroexpansion
2. stub out the called function so it doesn't launch the diff when the test runs.
