### PR TITLE
bumps org.flatland/ordered to 1.5.9

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
                  [org.clojure/clojure "1.6.0"]
                  [org.clojars.trptcolin/sjacket "0.1.4" :exclusions [org.clojure/clojure]]
                  [org.codehaus.jsr166-mirror/jsr166y "1.7.0"]
-                 [org.flatland/ordered "1.5.3"]]
+                 [org.flatland/ordered "1.5.9"]]
   :profiles {:1.3.0 {:dependencies [[org.clojure/clojure "1.3.0"]]}
              :1.4.0 {:dependencies [[org.clojure/clojure "1.4.0"]]}
              :1.5.1 {:dependencies [[org.clojure/clojure "1.5.1"]]}}


### PR DESCRIPTION
fixes flatland issue #45 with java 11
https://github.com/clj-commons/ordered/issues/45